### PR TITLE
refresh Packer object

### DIFF
--- a/modules/core/src/main/java/com/treasure_data/logger/sender/ExtendedPacker.java
+++ b/modules/core/src/main/java/com/treasure_data/logger/sender/ExtendedPacker.java
@@ -41,7 +41,7 @@ class ExtendedPacker {
     private ByteArrayOutputStream out;
     private GZIPOutputStream gzout;
     private List<String> keys;
-    private long rowSize;
+    private long rowCount;
 
     ExtendedPacker(MessagePack msgpack) throws IOException {
         this.msgpack = msgpack;
@@ -53,7 +53,7 @@ class ExtendedPacker {
         gzout = new GZIPOutputStream(out);
         packer = msgpack.createPacker(gzout);
         keys = new ArrayList<String>(KEY_SOFT_LIMIT);
-        rowSize = 0;
+        rowCount = 0;
     }
 
     synchronized ExtendedPacker write(Map<String, Object> v) throws IOException {
@@ -76,7 +76,7 @@ class ExtendedPacker {
             }
         }
         packer.writeMapEnd();
-        rowSize++;
+        rowCount++;
         return this;
     }
 
@@ -86,7 +86,7 @@ class ExtendedPacker {
 
     synchronized byte[] getByteArray() throws IOException {
         try {
-            gzout.finish();
+            gzout.close();
             return out.toByteArray();
 
         } finally {
@@ -94,7 +94,7 @@ class ExtendedPacker {
         }
     }
 
-    long getRowSize() {
-        return rowSize;
+    long getRowCount() {
+        return rowCount;
     }
 }

--- a/modules/core/src/main/java/com/treasure_data/logger/sender/HttpSender.java
+++ b/modules/core/src/main/java/com/treasure_data/logger/sender/HttpSender.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 import org.fluentd.logger.sender.Sender;
 import org.msgpack.MessagePack;
 
-import com.treasure_data.auth.TreasureDataCredentials;
 import com.treasure_data.client.TreasureDataClient;
 
 public class HttpSender implements Sender {
@@ -201,9 +200,9 @@ public class HttpSender implements Sender {
 
     protected void putQueue(String databaseName, String tableName, ExtendedPacker packer) {
         try {
-            long rowSize = packer.getRowSize();
-            byte[] bytes = packer.getByteArray(); // it should be called after getRowSize is called.
-            queue.put(new QueueEvent(databaseName, tableName, bytes, rowSize));
+            long rowCount = packer.getRowCount();
+            byte[] bytes = packer.getByteArray(); // it should be called after getRowCount is called.
+            queue.put(new QueueEvent(databaseName, tableName, bytes, rowCount));
 
         } catch (IOException e) { // ignore
             LOG.log(Level.WARNING, "Cannot execute getByteArray()", e);

--- a/modules/core/src/main/java/com/treasure_data/logger/sender/HttpSenderThread.java
+++ b/modules/core/src/main/java/com/treasure_data/logger/sender/HttpSenderThread.java
@@ -18,8 +18,6 @@
 package com.treasure_data.logger.sender;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -135,7 +133,7 @@ class HttpSenderThread implements Runnable {
         while (retry) {
             try {
                 LOG.info(String.format("Uploading event logs to %s.%s on TreasureData (%d bytes, %d records)",
-                        ev.databaseName, ev.tableName, ev.data.length, ev.rowSize));
+                        ev.databaseName, ev.tableName, ev.data.length, ev.rowCount));
 
                 Table table = new Table(new Database(ev.databaseName), ev.tableName);
 

--- a/modules/core/src/main/java/com/treasure_data/logger/sender/QueueEvent.java
+++ b/modules/core/src/main/java/com/treasure_data/logger/sender/QueueEvent.java
@@ -24,21 +24,21 @@ public class QueueEvent {
 
     public byte[] data;
 
-    public long rowSize;
+    public long rowCount;
 
     public QueueEvent() {
     }
 
-    public QueueEvent(String databaseName, String tableName, byte[] data, long rowSize) {
+    public QueueEvent(String databaseName, String tableName, byte[] data, long rowCount) {
         this.databaseName = databaseName;
         this.tableName = tableName;
         this.data = data;
-        this.rowSize = rowSize;
+        this.rowCount = rowCount;
     }
 
     @Override
     public String toString() {
-        return String.format("Event{database=%s,table=%s,data.size=%d, row.size=%d}",
-                new Object[] { databaseName, tableName, data.length, rowSize });
+        return String.format("Event{database=%s,table=%s,data.size=%d, row.count=%d}",
+                new Object[] { databaseName, tableName, data.length, rowCount});
     }
 }

--- a/modules/core/src/test/java/com/treasure_data/logger/sender/TestExtendedPacker.java
+++ b/modules/core/src/test/java/com/treasure_data/logger/sender/TestExtendedPacker.java
@@ -34,45 +34,27 @@ public class TestExtendedPacker {
 
         // expect
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        Packer packer = msgpack.createPacker(out);
-        for (int i = 0; i < 100; i++) {
-            Map<String, Object> data = new HashMap<String, Object>();
-            data.put("ki:" + i, "vi:" + i);
-            data.put("ki:" + i, i);
-            packer.write(data);
-        }
-        out.flush();
-        out.close();
-        byte[] expected = out.toByteArray();
-        out = new ByteArrayOutputStream();
         GZIPOutputStream gzout = new GZIPOutputStream(out);
-        gzout.write(expected);
-        gzout.finish();
-        int expectedSize = out.size();
+        Packer packer = msgpack.createPacker(gzout);
 
         // actual
         ExtendedPacker extpacker = new ExtendedPacker(msgpack);
+
         for (int i = 0; i < 100; i++) {
             Map<String, Object> data = new HashMap<String, Object>();
             data.put("ki:" + i, "vi:" + i);
             data.put("ki:" + i, i);
+
+            packer.write(data);
             extpacker.write(data);
         }
-        out = new ByteArrayOutputStream();
-        GZIPInputStream gzin = new GZIPInputStream(new ByteArrayInputStream(extpacker.getByteArray()));
-        while (true) {
-            int len = gzin.read();
-            if (len < 0) {
-                break;
-            }
-            out.write(len);
-        }
-        out.flush();
-        out.close();
-        byte[] actual = out.toByteArray();
 
-        assertEquals(expectedSize, extpacker.getChunkSize());
-        assertArrayEquals(expected, actual);
+        packer.flush();
+        gzout.finish();
+
+        assertArrayEquals(out.toByteArray(), extpacker.getByteArray());
+
+        gzout.close();
     }
 
     @Test


### PR DESCRIPTION
When td-logger flushes, all buffers are recreated (all ExtendedPacker objects are removed). but, the behavior doesn't make sense and has the risk of race condition potentially. The following is the fix:
* ExtendedPacker objects are reused.
  * ExtendedPacker#write and getByteArray should be synchronized.
  * ExtendedPacker#refresh method is added.
* HttpSender doesn't need to recreate ExtendedPacker objects.
