### PR TITLE
adding coverage information to support td_beda

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 test:
   override:
     - mvn test -P core
+    - cp -af target/site/* $CIRCLE_ARTIFACTS
 
 notify:
   webhooks:


### PR DESCRIPTION
There are few projects which does not have coverage information in td_beda. This is one such project. Adding this line to verify whether it will fix the issue. Interesting to note this ticket: https://github.com/treasure-data/td-logger-java/commit/faf1b05a291d620620ed59ee4dce4ef6263db1f7